### PR TITLE
fix it better

### DIFF
--- a/Pod/Classes/Annotations/PDFAnnotationController.swift
+++ b/Pod/Classes/Annotations/PDFAnnotationController.swift
@@ -146,7 +146,7 @@ open class PDFAnnotationController: UIViewController {
         annotationType = type
         
         view.isUserInteractionEnabled = annotationType != nil
-        undoButton.isEnabled = annotationType != nil
+        undoButton.isEnabled = (annotationType != nil || annotations.annotations.count > 0)
     }
     
     open func finishAnnotation() {


### PR DESCRIPTION
- undo should still be enabled if you start an empty annotation while there are annotations in the store